### PR TITLE
Revert "Add clamav-unofficial-sigs"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/gitscan.sh"]
 
 RUN apk add --no-cache --update clamav-libunrar freshclam clamav-scanner \
-    clamav-unofficial-sigs \
     bash dumb-init \
     git 
 RUN freshclam


### PR DESCRIPTION
Reverts djdefi/gitavscan#26

Apparently is not available in `apk` -- will need to look into this further.

