### PR TITLE
Allow additional options to be passed to clamscan

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,5 @@ jobs:
         fetch-depth: '0'
     - name: Git AV Scan
       uses: djdefi/gitavscan@main
+      with:
+        options: '--max-filesize=1M'

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -43,3 +43,7 @@ jobs:
       - name: Run basic scan
         run: |
           docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh | grep "Win.Test.EICAR_HDB-1 FOUND"
+      
+      - name: Run basic scan with optional args
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --options "--max-filesize=1M --max-files=15" | grep "Win.Test.EICAR_HDB-1 FOUND"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ with:
 
 ## Example workflow
 
-Deep history scan. Scans each commit in the repositry history. Slow but thorough:
+Deep history scan. Scans each commit in the repository history. Slow but thorough:
 
 ```yaml
 on: [push]
@@ -51,6 +51,26 @@ jobs:
     - name: Git AV Scan
       uses: djdefi/gitavscan@main
 ``` 
+
+### Passing options to `clamscan`
+
+Setting additional [`clamscan` command line options](https://linux.die.net/man/1/clamscan) is supported. This can be used to limit or exclude directories from the scope of the scan.
+
+```yaml
+on: [push]
+jobs:
+  gitavscan:
+    runs-on: ubuntu-latest
+    name: History AV Scan
+    steps:
+    - uses: actions/checkout@main
+      with:
+        fetch-depth: '0'
+    - name: Git AV Scan
+      uses: djdefi/gitavscan@main
+      with:
+        options: '--max-filesize=1M'
+```        
 
 ## Running locally with Docker
 

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ runs:
   args:
     - '/gitscan.sh'
     - ${{ inputs.full }}
+    - ${{ inputs.options }}
 branding:
   icon: 'shield'  
   color: 'orange'


### PR DESCRIPTION
Addresses #20 as well as opening up other use cases by allowing [`clamscan` options](https://linux.die.net/man/1/clamscan) to be passed through to the `clamscan` command.
