### PR TITLE
Use getopt

### DIFF
--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -47,3 +47,14 @@ jobs:
       - name: Run basic scan with optional args
         run: |
           docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --options "--max-filesize=1M --max-files=15" | grep "Win.Test.EICAR_HDB-1 FOUND"
+      
+      - name: Test unknown option
+        run: |
+          output=$(docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --unknown-option || true)
+          echo "$output" | grep "Usage:"
+        
+      - name: Run scan on non-Git directory
+        run: |
+          mkdir non_git_dir
+          output=$(docker run --rm -v $GITHUB_WORKSPACE/non_git_dir:/scandir gitavscan /gitscan.sh || true)
+          echo "$output" | grep "ERROR: Not a git repository, skipping history scan."

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -51,4 +51,4 @@ jobs:
       - name: Test unknown option
         run: |
           output=$(docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --unknown-option || true)
-          echo "$output" | grep "Usage:"
+          echo "$output" | grep "OPTIONS:"

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -52,9 +52,3 @@ jobs:
         run: |
           output=$(docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --unknown-option || true)
           echo "$output" | grep "Usage:"
-        
-      - name: Run scan on non-Git directory
-        run: |
-          mkdir non_git_dir
-          output=$(docker run --rm -v $GITHUB_WORKSPACE/non_git_dir:/scandir gitavscan /gitscan.sh || true)
-          echo "$output" | grep "ERROR: Not a git repository, skipping history scan."

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ CMD ["/gitscan.sh"]
 
 RUN apk add --no-cache --update clamav-libunrar freshclam clamav-scanner \
     bash dumb-init \
-    git 
+    git
+RUN git config --global --add safe.directory /scandir
 RUN freshclam
 
 COPY gitscan.sh /

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -31,7 +31,8 @@ ADDITIONAL_OPTIONS=""
 VERBOSE_MODE="false"
 
 # read the options
-TEMP=$(getopt -o vf:o: --long verbose,full,options: -n "$0" -- "$@")
+# read the options
+TEMP=$(getopt -o vf:o: --long verbose,full,options: -n "$0" -- "$@") || { usage; exit 1; }
 eval set -- "$TEMP"
 
 # extract options and their arguments into variables.

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -47,7 +47,7 @@ while true ; do
                 *) ADDITIONAL_OPTIONS="$2"; shift 2 ;;
             esac ;;
         --) shift ; break ;;
-        *) echo "Internal error!" ; exit 1 ;;
+        *) echo "Internal error!" ; usage; exit 1 ;;
     esac
 done
 

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -47,7 +47,7 @@ while true ; do
                 *) ADDITIONAL_OPTIONS="$2"; shift 2 ;;
             esac ;;
         --) shift ; break ;;
-        *) echo "Internal error!" ; usage; exit 1 ;;
+        *) echo "Invalid option: $1"; usage; exit 1 ;;
     esac
 done
 

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -25,28 +25,30 @@ usage() {
   grep '^#/' < "$0" | cut -c 4-
 }
 
+# set default values
+FULL_SCAN="false"
 ADDITIONAL_OPTIONS=""
+VERBOSE_MODE="false"
 
-for arg in "$@"
-do
-  case $arg in
-    -h|--help)
-      usage
-      exit 2
-      ;;
-    -f|--full)
-      FULL_SCAN="true"
-      shift
-      ;;
-    -o|--options)
-      ADDITIONAL_OPTIONS="$2"
-      shift
-      shift
-      ;;
-    *)
-      shift
-      ;;
-  esac
+# read the options
+TEMP=$(getopt -o vf:o: --long verbose,full,options: -n "$0" -- "$@")
+eval set -- "$TEMP"
+
+# extract options and their arguments into variables.
+while true ; do
+    case "$1" in
+        -v|--verbose)
+            VERBOSE_MODE="true"; shift ;;
+        -f|--full)
+            FULL_SCAN="true"; shift ;;
+        -o|--options)
+            case "$2" in
+                "") shift 2 ;;
+                *) ADDITIONAL_OPTIONS="$2"; shift 2 ;;
+            esac ;;
+        --) shift ; break ;;
+        *) echo "Internal error!" ; exit 1 ;;
+    esac
 done
 
 /usr/bin/freshclam


### PR DESCRIPTION
This pull request includes changes to the `gitscan.sh` script to improve its usability and functionality. The most important change is that the script now uses `getopt` to extract command line options and has default values for certain variables.

Main interface changes:

* <a href="diffhunk://#diff-70a4d0a31f2258eab4d5c517d2e1ee0656ae4da6f2a7f427feb0f8e70706d67dR28-R50">`gitscan.sh`</a>: Updated the script to use `getopt` to extract command line options and added default values for certain variables.