### PR TITLE
Full scan blobs not commits

### DIFF
--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -78,4 +78,9 @@ jobs:
 
       - name: Run full scan
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --full | grep "Win.Test.EICAR_HDB-1 FOUND"
+          docker run --rm -t -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --full | tee scan_results.txt
+
+      - name: Check scan results for EICAR test
+        run: |
+          grep "Win.Test.EICAR_HDB-1 FOUND" scan_results.txt
+        

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -57,15 +57,18 @@ jobs:
           
       - name: Create unreachable commit
         run: |
-          # This will create a blob from the file and print the SHA1 hash of the created blob
+          # These commands will create a blob from the file and print the SHA1 hash of the created blob
           blob=$(git hash-object -w eicar_com.zip) 
           echo $blob
-          # This will create a new tree with the blob
-          tree=$(echo -e "100644 blob $blob unreachable-virus" | git mktree)
-          # This creates a new commit with the tree
+          
+          # These commands will create a new tree with the blob, please note the '\t' which is the tab character between blob and filename.
+          tree=$(echo -e "100644 blob $blob\tunreachable-virus" | git mktree)
+          
+          # This command creates a new commit with the tree
           commit=$(git commit-tree $tree -m "Add an unreachable commit with a virus")
+          
           echo "Unreachable commit with a virus created: $commit"
-
+            
           # Delete the test viruses
           rm -rf eicar.com*
 

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -51,6 +51,10 @@ jobs:
           
       - name: Create an unreachable commit with virus 
         run: |
+          # Setup Git
+          git config --global user.email "gitavscan@example.com"
+          git config --global user.name "Evil Git"
+          
           # Create a new orphan branch 
           git checkout --orphan temp_branch 
       

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -13,13 +13,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+      
+      - name: Setup Git
+        run: |
+          git config --global user.email "gitavscan@example.com"
+          git config --global user.name "Evil Git"
+          
       - name: Download EICAR test files
         run: |
           wget "https://secure.eicar.org/eicar.com.txt"
           wget "https://secure.eicar.org/eicar.com"
           wget "https://secure.eicar.org/eicar_com.zip"
           wget "https://secure.eicar.org/eicarcom2.zip"
+          git add .
+          git commit -m "Add EICAR test files"
       
       - name: Build image
         run: docker build -t gitavscan .
@@ -40,23 +47,21 @@ jobs:
         run: |
           output=$(docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --unknown-option || true)
           echo "$output" | grep "OPTIONS:"
-          
-      - name: Setup Git
-        run: |
-          git config --global user.email "gitavscan@example.com"
-          git config --global user.name "Evil Git"
-          
+            
       - name: Create unreachable commit
         id: create_unreachable
         run: |
-          blob=$(git hash-object -w eicar_com.zip) 
-          echo "Blob SHA: $blob"
+          blob_txt=$(git hash-object -w eicar.com.txt) 
+          blob_com=$(git hash-object -w eicar.com) 
+          blob_zip=$(git hash-object -w eicar_com.zip) 
+          blob_zip2=$(git hash-object -w eicarcom2.zip) 
           
-          tree=$(echo -e "100644 blob $blob\tunreachable-virus" | git mktree)
-          echo "Tree SHA: $tree"
+          tree=$(echo -e "100644 blob $blob_txt\tunreachable-virus.txt
+          100644 blob $blob_com\tunreachable-virus.com
+          100644 blob $blob_zip\tunreachable-virus.zip
+          100644 blob $blob_zip2\tunreachable-virus2.zip" | git mktree)
           
-          commit=$(git commit-tree $tree -m "Add an unreachable commit with a virus")
-          echo "Unreachable commit with a virus created: $commit"
+          commit=$(git commit-tree $tree -m "Add an unreachable commit with viruses")
           echo "::set-output name=SHA_HASH::$commit"
           
           rm -rf eicar*

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run basic scan
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh > scan_results.txt
+          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh | tee -a scan_results.txt
       
       - name: Check scan results
         run: |

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -55,16 +55,15 @@ jobs:
           git config --global user.email "gitavscan@example.com"
           git config --global user.name "Evil Git"
           
-          # Create a new orphan branch 
-          git checkout --orphan temp_branch 
-      
-          # Add a virus file to the branch and commit it
-          git add eicar.com.txt
-          git commit -m "Add virus to an orphan branch"
-      
-          # Delete the orphan branch which makes the commit unreachable 
-          git checkout main
-          git branch -D temp_branch
+      - name: Create unreachable commit
+        run: |
+          # This will create a blob from the file and print the SHA1 hash of the created blob
+          blob=$(git hash-object -w eicar_com.zip) 
+          # This will create a new tree with the blob
+          tree=$(echo "100644 blob $blob\tunreachable-virus" | git mktree)
+          # This creates a new commit with the tree
+          commit=$(git commit-tree $tree -m "Add an unreachable commit with a virus")
+          echo "Unreachable commit with a virus created: $commit"
 
           # Delete the test viruses
           rm -rf eicar.com*

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -38,8 +38,12 @@ jobs:
 
       - name: Run basic scan
         run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh | grep "Win.Test.EICAR_HDB-1 FOUND"
+          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh > scan_results.txt
       
+      - name: Check scan results
+        run: |
+          cat scan_results.txt | grep "Win.Test.EICAR_HDB-1 FOUND"
+
       - name: Run basic scan with optional args
         run: |
           docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --options "--max-filesize=1M --max-files=15" | grep "Win.Test.EICAR_HDB-1 FOUND"

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -70,7 +70,7 @@ jobs:
           echo "Unreachable commit with a virus created: $commit"
             
           # Delete the test viruses
-          rm -rf eicar.com*
+          rm -rf eicar*
 
       - name: Run full scan
         run: |

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -53,7 +53,7 @@ jobs:
           output=$(docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --unknown-option || true)
           echo "$output" | grep "OPTIONS:"
           
-      - name: Create an unreachable commit with virus 
+      - name: Setup Git
         run: |
           # Setup Git
           git config --global user.email "gitavscan@example.com"

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -1,31 +1,19 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Scan test
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   scan-test:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Download test virii
       - name: Download EICAR test files
         run: |
           wget "https://secure.eicar.org/eicar.com.txt"
@@ -55,25 +43,22 @@ jobs:
           
       - name: Setup Git
         run: |
-          # Setup Git
           git config --global user.email "gitavscan@example.com"
           git config --global user.name "Evil Git"
           
       - name: Create unreachable commit
+        id: create_unreachable
         run: |
-          # These commands will create a blob from the file and print the SHA1 hash of the created blob
           blob=$(git hash-object -w eicar_com.zip) 
-          echo $blob
+          echo "Blob SHA: $blob"
           
-          # These commands will create a new tree with the blob, please note the '\t' which is the tab character between blob and filename.
           tree=$(echo -e "100644 blob $blob\tunreachable-virus" | git mktree)
+          echo "Tree SHA: $tree"
           
-          # This command creates a new commit with the tree
           commit=$(git commit-tree $tree -m "Add an unreachable commit with a virus")
-          
           echo "Unreachable commit with a virus created: $commit"
-            
-          # Delete the test viruses
+          echo "::set-output name=SHA_HASH::$commit"
+          
           rm -rf eicar*
 
       - name: Run full scan
@@ -83,4 +68,12 @@ jobs:
       - name: Check scan results for EICAR test
         run: |
           grep "Win.Test.EICAR_HDB-1 FOUND" scan_results.txt
-        
+
+      - name: Check for unreachable commit in scan results
+        run: |
+          if grep -q "${{ steps.create_unreachable.outputs.SHA_HASH }}" scan_results.txt; then
+            echo "Unreachable commit detected in scan results."
+          else
+            echo "Unreachable commit not detected in scan results."
+            exit 1
+          fi

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -35,10 +35,6 @@ jobs:
       
       - name: Build image
         run: docker build -t gitavscan .
-      
-      - name: Run full scan
-        run: |
-          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --full | grep "Win.Test.EICAR_HDB-1 FOUND"
 
       - name: Run basic scan
         run: |
@@ -52,3 +48,23 @@ jobs:
         run: |
           output=$(docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --unknown-option || true)
           echo "$output" | grep "OPTIONS:"
+          
+      - name: Create an unreachable commit with virus 
+        run: |
+          # Create a new orphan branch 
+          git checkout --orphan temp_branch 
+      
+          # Add a virus file to the branch and commit it
+          git add eicar.com.txt
+          git commit -m "Add virus to an orphan branch"
+      
+          # Delete the orphan branch which makes the commit unreachable 
+          git checkout main
+          git branch -D temp_branch
+
+          # Delete the test viruses
+          rm -rf eicar.com*
+
+      - name: Run full scan
+        run: |
+          docker run --rm -v $GITHUB_WORKSPACE:/scandir gitavscan /gitscan.sh --full | grep "Win.Test.EICAR_HDB-1 FOUND"

--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -59,8 +59,9 @@ jobs:
         run: |
           # This will create a blob from the file and print the SHA1 hash of the created blob
           blob=$(git hash-object -w eicar_com.zip) 
+          echo $blob
           # This will create a new tree with the blob
-          tree=$(echo "100644 blob $blob\tunreachable-virus" | git mktree)
+          tree=$(echo -e "100644 blob $blob unreachable-virus" | git mktree)
           # This creates a new commit with the tree
           commit=$(git commit-tree $tree -m "Add an unreachable commit with a virus")
           echo "Unreachable commit with a virus created: $commit"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ CMD ["/gitscan.sh"]
 RUN apk add --no-cache --update clamav-libunrar freshclam clamav-scanner \
     bash dumb-init \
     git
+RUN git config --global --add safe.directory /scandir    
 RUN freshclam
 
 COPY gitscan.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ CMD ["/gitscan.sh"]
 RUN apk add --no-cache --update clamav-libunrar freshclam clamav-scanner \
     bash dumb-init \
     git
-RUN git config --global --add safe.directory /scandir    
+RUN git config --global --add safe.directory /scandir
 RUN freshclam
 
 COPY gitscan.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ CMD ["/gitscan.sh"]
 RUN apk add --no-cache --update clamav-libunrar freshclam clamav-scanner \
     bash dumb-init \
     git
-RUN git config --global --add safe.directory /scandir
 RUN freshclam
 
 COPY gitscan.sh /

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   full:  
     description: 'Full history scan'
     required: false
+  options:
+    description: 'Additional options for clamscan command'
+    required: false
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/djdefi/gitavscan:nightly'

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -91,7 +91,9 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
     
     # Use grep to verify that this is indeed a blob and not a tree or commit
     if [ $(git cat-file -t $blob) = "blob" ]; then
-      output=$($SCRIPT)
+      git cat-file -p $blob > $TMP/blob
+      output=$($SCRIPT $TMP/blob)
+      rm $TMP/blob
     fi
     
     if echo "$output" | grep -q "FOUND"; then

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -93,7 +93,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   current_object=0
 
   progress "Scanning all git objects (Total: $total_objects)..."
-  for object in ${objects}; do
+  echo "$objects" | while read -r object; do
     current_object=$((current_object + 1))
     progress "Scanning object $current_object of $total_objects..."
     

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -18,8 +18,12 @@
 #/    
 #/    Scan with additional clamscan options.
 #/      $ gitscan.sh --options "--max-filesize=1M"
-#/        
+#/
+
 set -o nounset -o pipefail
+
+LOG_FILE="gitscan.log"
+echo "Starting Git Repository Scan" > "$LOG_FILE"
 
 usage() {
   grep '^#/' < "$0" | cut -c 4-
@@ -30,7 +34,6 @@ FULL_SCAN="false"
 ADDITIONAL_OPTIONS=""
 VERBOSE_MODE="false"
 
-# read the options
 # read the options
 TEMP=$(getopt -o vf:o: --long verbose,full,options: -n "$0" -- "$@") || { usage; exit 1; }
 eval set -- "$TEMP"
@@ -57,7 +60,7 @@ done
 echo "Beginning scan..."
 
 if ! [ -d ".git" ]; then
-  echo "ERROR: Not a git repository, skipping history scan."
+  echo "ERROR: Not a git repository, skipping history scan." | tee -a "$LOG_FILE"
   exit 1
 fi
 
@@ -66,31 +69,42 @@ SCRIPT="/usr/bin/clamscan -ri --no-summary $ADDITIONAL_OPTIONS"
 TMP=$(mktemp -d -q)
 REPO=$(pwd)
 
-echo "Scanning working and .git directories..."
+echo "Scanning working and .git directories..." | tee -a "$LOG_FILE"
 output=$($SCRIPT)
+if [ $? -ne 0 ]; then
+  echo "Error during scanning working and .git directories" | tee -a "$LOG_FILE"
+else
   if echo "$output" | grep -q "FOUND"; then
     echo "Found malicious file in ref $(git rev-parse HEAD)" | tee -a /output.txt
     echo "$output" | tee -a /output.txt
   fi
+fi
 
 if [[ "${FULL_SCAN:-}" = "true" ]]; then
   # clone the git repository
   pushd $TMP > /dev/null 2>&1
-  git clone $REPO 2> /dev/null 1>&2
+  if ! git clone $REPO 2>> "$LOG_FILE" 1>&2; then
+    echo "Failed to clone repository: $REPO" | tee -a "$LOG_FILE"
+    exit 1
+  fi
   cd $(basename $REPO)
 
-  # Process blobs
-  blobs=$(git rev-list --objects --all --filter=blob:limit=100k)
-  echo "Inspecting $blobs blobs..."
+  # Process all blobs
+  blobs=$(git rev-list --objects --all)
+  echo "Inspecting $blobs blobs..." | tee -a "$LOG_FILE"
   
   for blob in ${blobs}; do
     objtype=$(git cat-file -t ${blob})
     if [[ ${objtype} == "blob" ]]; then
       output=$(${SCRIPT} <(git cat-file blob ${blob}))
-      if echo "${output}" | grep -q "FOUND"; then
+      if [ $? -ne 0 ]; then
+        echo "Error scanning blob: ${blob}" | tee -a "$LOG_FILE"
+      elif echo "${output}" | grep -q "FOUND"; then
         echo "Found malicious file in blob ${blob}" | tee -a /output.txt
         echo "${output}" | tee -a /output.txt
       fi
+    else
+      echo "Skipping non-blob object: ${blob}" | tee -a "$LOG_FILE"
     fi
   done
 
@@ -100,9 +114,9 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
 fi
 
 if [ -s "/output.txt" ]; then
-  echo "Scan finished with detections $(date)"
-  cat /output.txt
+  echo "Scan finished with detections $(date)" | tee -a "$LOG_FILE"
+  cat /output.txt | tee -a "$LOG_FILE"
   exit 1
+else
+  echo "Scan finished without detections $(date)" | tee -a "$LOG_FILE"
 fi
-
-echo "Scan finished $(date)"

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -88,7 +88,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   fi
 
   # Get a list of all objects (blobs, trees, commits, etc.)
-  objects=$(git rev-list --objects --all)
+  objects=$(git rev-list --objects --all --unreachable)
   total_objects=$(echo "$objects" | wc -l)
   current_object=0
 

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -103,6 +103,14 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
       fi
     fi
   done
+  
+  # Find and scan unreachable objects
+  echo "Scanning for unreachable objects..."
+  unreachable_objects=$(git fsck --unreachable | awk '/blob/ {print $3}')
+  for object in $unreachable_objects; do
+    git cat-file -p $object | $SCRIPT
+  done
+
 fi
 
 if [ -s "/output.txt" ]; then

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -113,6 +113,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   progress "Scanning for unreachable objects..."
   unreachable_objects=$(git fsck --unreachable | awk '/blob/ {print $3}')
   for object in $unreachable_objects; do
+    echo "Scanning unreachable object: $object"
     git cat-file -p $object | $SCRIPT
   done
 

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -78,13 +78,13 @@ else
 fi
 
 if [[ "${FULL_SCAN:-}" = "true" ]]; then
-  TMP=$(mktemp -d -q)
-  if ! git clone $REPO $TMP/cloned_repo 2>&1; then
-    echo "Failed to clone repository: $REPO"
+  # Ensure we are in a Git repository
+  if ! [ -d ".git" ]; then
+    echo "ERROR: Not a git repository, cannot perform full scan."
     exit 1
   fi
 
-  pushd $TMP/cloned_repo > /dev/null 2>&1
+  REPO=$(pwd)
 
   # Process all blobs
   blobs=$(git rev-list --objects --all)
@@ -104,9 +104,6 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
       echo "Skipping non-blob object: ${blob}"
     fi
   done
-
-  popd > /dev/null
-  rm -rf $TMP
 fi
 
 if [ -s "/output.txt" ]; then

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -78,17 +78,13 @@ else
 fi
 
 if [[ "${FULL_SCAN:-}" = "true" ]]; then
-  # Create a bundle of the entire repository including unreachable objects
-  BUNDLE_FILE=$(mktemp)
-  git bundle create "$BUNDLE_FILE" --all
-
-  # Clone from the bundle
-  pushd $TMP > /dev/null 2>&1
-  if ! git clone "$BUNDLE_FILE" cloned_repo 2>&1; then
-    echo "Failed to clone from bundle"
+  TMP=$(mktemp -d -q)
+  if ! git clone $REPO $TMP/cloned_repo 2>&1; then
+    echo "Failed to clone repository: $REPO"
     exit 1
   fi
-  cd cloned_repo
+
+  pushd $TMP/cloned_repo > /dev/null 2>&1
 
   # Process all blobs
   blobs=$(git rev-list --objects --all)
@@ -111,7 +107,6 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
 
   popd > /dev/null
   rm -rf $TMP
-  rm "$BUNDLE_FILE"
 fi
 
 if [ -s "/output.txt" ]; then

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -80,7 +80,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   cd $(basename $REPO)
 
   # Process blobs
-  blobs=$(git rev-list --objects --all --filter=blob)
+  blobs=$(git rev-list --objects --all --filter=blob:limit=100k)
   echo "Inspecting $blobs blobs..."
   
   for blob in ${blobs}; do

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -86,22 +86,21 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
 
   REPO=$(pwd)
 
-  # Process all blobs
-  blobs=$(git rev-list --objects --all)
-  echo "Inspecting $blobs blobs..."
-  
-  for blob in ${blobs}; do
-    objtype=$(git cat-file -t ${blob})
-    if [[ ${objtype} == "blob" ]]; then
-      output=$(${SCRIPT} <(git cat-file blob ${blob}))
+  # Get a list of all objects (blobs, trees, commits, etc.)
+  objects=$(git rev-list --objects --all)
+
+  # Process each object
+  for object in ${objects}; do
+    # Check if the object is a blob
+    if [[ $(git cat-file -t "$object" 2>/dev/null) == "blob" ]]; then
+      # It's a blob, proceed with scanning
+      output=$(${SCRIPT} <(git cat-file blob "$object"))
       if [ $? -ne 0 ]; then
-        echo "Error scanning blob: ${blob}"
+        echo "Error scanning blob: ${object}"
       elif echo "${output}" | grep -q "FOUND"; then
-        echo "Found malicious file in blob ${blob}"
+        echo "Found malicious file in blob ${object}"
         echo "${output}"
       fi
-    else
-      echo "Skipping non-blob object: ${blob}"
     fi
   done
 fi

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -85,7 +85,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   echo "Inspecting $blobs blobs..."
 
   # scan all
-  for blob in $(git rev-list --objects --all --filter=tree:0); do
+  for blob in $(git rev-list --objects --all); do
     echo "Scanning blob $count of $blobs: $blob"
     git cat-file -p $blob 2> /dev/null 1>&2
     

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -88,7 +88,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   fi
 
   # Get a list of all objects (blobs, trees, commits, etc.)
-  objects=$(git rev-list --objects --all --unreachable)
+  objects=$(git rev-list --objects --all)
   total_objects=$(echo "$objects" | wc -l)
   current_object=0
 

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -18,12 +18,9 @@
 #/    
 #/    Scan with additional clamscan options.
 #/      $ gitscan.sh --options "--max-filesize=1M"
-#/
+#/        
 
 set -o nounset -o pipefail
-
-LOG_FILE="gitscan.log"
-echo "Starting Git Repository Scan" > "$LOG_FILE"
 
 usage() {
   grep '^#/' < "$0" | cut -c 4-
@@ -60,7 +57,7 @@ done
 echo "Beginning scan..."
 
 if ! [ -d ".git" ]; then
-  echo "ERROR: Not a git repository, skipping history scan." | tee -a "$LOG_FILE"
+  echo "ERROR: Not a git repository, skipping history scan."
   exit 1
 fi
 
@@ -69,42 +66,42 @@ SCRIPT="/usr/bin/clamscan -ri --no-summary $ADDITIONAL_OPTIONS"
 TMP=$(mktemp -d -q)
 REPO=$(pwd)
 
-echo "Scanning working and .git directories..." | tee -a "$LOG_FILE"
+echo "Scanning working and .git directories..."
 output=$($SCRIPT)
 if [ $? -ne 0 ]; then
-  echo "Error during scanning working and .git directories" | tee -a "$LOG_FILE"
+  echo "Error during scanning working and .git directories"
 else
   if echo "$output" | grep -q "FOUND"; then
-    echo "Found malicious file in ref $(git rev-parse HEAD)" | tee -a /output.txt
-    echo "$output" | tee -a /output.txt
+    echo "Found malicious file in ref $(git rev-parse HEAD)"
+    echo "$output"
   fi
 fi
 
 if [[ "${FULL_SCAN:-}" = "true" ]]; then
   # clone the git repository
   pushd $TMP > /dev/null 2>&1
-  if ! git clone $REPO 2>> "$LOG_FILE" 1>&2; then
-    echo "Failed to clone repository: $REPO" | tee -a "$LOG_FILE"
+  if ! git clone $REPO 2>&1; then
+    echo "Failed to clone repository: $REPO"
     exit 1
   fi
   cd $(basename $REPO)
 
   # Process all blobs
   blobs=$(git rev-list --objects --all)
-  echo "Inspecting $blobs blobs..." | tee -a "$LOG_FILE"
+  echo "Inspecting $blobs blobs..."
   
   for blob in ${blobs}; do
     objtype=$(git cat-file -t ${blob})
     if [[ ${objtype} == "blob" ]]; then
       output=$(${SCRIPT} <(git cat-file blob ${blob}))
       if [ $? -ne 0 ]; then
-        echo "Error scanning blob: ${blob}" | tee -a "$LOG_FILE"
+        echo "Error scanning blob: ${blob}"
       elif echo "${output}" | grep -q "FOUND"; then
-        echo "Found malicious file in blob ${blob}" | tee -a /output.txt
-        echo "${output}" | tee -a /output.txt
+        echo "Found malicious file in blob ${blob}"
+        echo "${output}"
       fi
     else
-      echo "Skipping non-blob object: ${blob}" | tee -a "$LOG_FILE"
+      echo "Skipping non-blob object: ${blob}"
     fi
   done
 
@@ -114,9 +111,9 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
 fi
 
 if [ -s "/output.txt" ]; then
-  echo "Scan finished with detections $(date)" | tee -a "$LOG_FILE"
-  cat /output.txt | tee -a "$LOG_FILE"
+  echo "Scan finished with detections $(date)"
+  cat /output.txt
   exit 1
 else
-  echo "Scan finished without detections $(date)" | tee -a "$LOG_FILE"
+  echo "Scan finished without detections $(date)"
 fi

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -69,7 +69,7 @@ REPO=$(pwd)
 echo "Scanning working and .git directories..."
 output=$($SCRIPT 2>&1)
 if [ $? -ne 0 ]; then
-  echo "ClamScan Error: $output"
+  echo "ClamScan Output: $output"
 else
   if echo "$output" | grep -q "FOUND"; then
     echo "Found malicious file in ref $(git rev-parse HEAD)"

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -67,9 +67,9 @@ TMP=$(mktemp -d -q)
 REPO=$(pwd)
 
 echo "Scanning working and .git directories..."
-output=$($SCRIPT)
+output=$($SCRIPT 2>&1)
 if [ $? -ne 0 ]; then
-  echo "Error during scanning working and .git directories"
+  echo "ClamScan Error: $output"
 else
   if echo "$output" | grep -q "FOUND"; then
     echo "Found malicious file in ref $(git rev-parse HEAD)"

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -110,8 +110,8 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   done
   
   # Find and scan unreachable objects
-  progress "Scanning for unreachable objects..."
-  unreachable_objects=$(git fsck --unreachable | awk '/blob/ {print $3}')
+  progress "Scanning for unreachable or lost objects..."
+  unreachable_objects=$(git fsck --unreachable --lost-found | awk '/blob/ {print $3}')
   for object in $unreachable_objects; do
     echo "Scanning unreachable object: $object"
     git cat-file -p $object | $SCRIPT

--- a/gitscan.sh
+++ b/gitscan.sh
@@ -111,7 +111,7 @@ if [[ "${FULL_SCAN:-}" = "true" ]]; then
   
   # Find and scan unreachable objects
   progress "Scanning for unreachable or lost objects..."
-  unreachable_objects=$(git fsck --unreachable --lost-found | awk '/blob/ {print $3}')
+  unreachable_objects=$(git fsck --full | awk '/blob/ {print $3}')
   for object in $unreachable_objects; do
     echo "Scanning unreachable object: $object"
     git cat-file -p $object | $SCRIPT


### PR DESCRIPTION
This pull request includes modifications to improve the scanning process in the codebase. The most important changes include modifying the `gitscan.sh` script to count the number of blobs instead of commits and updating the `.github/workflows/test-scan.yml` file to add a new job for creating an unreachable commit with a virus.

Main scanning improvements:

* <a href="diffhunk://#diff-70a4d0a31f2258eab4d5c517d2e1ee0656ae4da6f2a7f427feb0f8e70706d67dL82-R98">`gitscan.sh`</a>: Modified the script to count the number of blobs instead of commits and updated the output file to indicate the blob number instead of the commit number.
* <a href="diffhunk://#diff-b22321560b8cf7bffc864392234175870515d75d63e62c3ff55b779759e0ce2dL39-L42">`.github/workflows/test-scan.yml`</a>: Removed the "Run full scan" job and added a new job named "Create an unreachable commit with virus" to the workflow file.