### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-scan.yml
+++ b/.github/workflows/test-scan.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"


### PR DESCRIPTION
Potential fix for [https://github.com/djdefi/gitavscan/security/code-scanning/17](https://github.com/djdefi/gitavscan/security/code-scanning/17)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged.  
Best fix here: set workflow-level permissions to `contents: read` right after the `on`/`workflow_dispatch` section and before `jobs`. This preserves current functionality (checkout and test execution) while satisfying CodeQL and documenting intent.

File to change:
- `.github/workflows/test-scan.yml`  
Region:
- Insert between current line 15 and line 17 (after `workflow_dispatch:` and before `jobs:`)

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
